### PR TITLE
[fix] customerテーブルの電話番号をtelからtelephone_numberに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,8 +23,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :zip_code, :address, :tel, :is_active ])
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :zip_code, :address, :telephone_number, :is_active ])
   end
 
 end

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -30,8 +30,8 @@
   </div>
 
   <div class="field">
-    <%= f.label :tel, "電話番号(ハイフンなし)" %>
-    <%= f.text_field :tel %>
+    <%= f.label :telephone_number, "電話番号(ハイフンなし)" %>
+    <%= f.text_field :telephone_number %>
   </div>
 
   <div class="field">

--- a/db/migrate/20231114024345_rename_tel_column_to_customers.rb
+++ b/db/migrate/20231114024345_rename_tel_column_to_customers.rb
@@ -1,0 +1,5 @@
+class RenameTelColumnToCustomers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :customers, :tel, :telephone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_13_075438) do
+ActiveRecord::Schema.define(version: 2023_11_14_024345) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "customer_id", null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 2023_11_13_075438) do
     t.string "last_name_kana", null: false
     t.string "zip_code", null: false
     t.string "address", null: false
-    t.string "tel", null: false
+    t.string "telephone_number", null: false
     t.boolean "is_active", default: true, null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"


### PR DESCRIPTION
 指摘のあった顧客のテーブル名を変更しました。
 tel => telephone_number

marge-pullの後、
db:migrate
の実行をお願いします。