### PR TITLE
[add] 顧客注文履歴一覧のルーティング

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,6 +1,6 @@
 class Admin::CustomersController < ApplicationController
   before_action :authenticate_admin!
-  before_action :set_customer, only: %i[show edit update]
+  before_action :set_customer, only: %i[show edit update orders]
 
   def index
     @customers = Customer.page(params[:page])
@@ -10,6 +10,10 @@ class Admin::CustomersController < ApplicationController
   end
 
   def edit
+  end
+
+  def orders
+    @orders = @customer.orders
   end
 
   def update

--- a/app/views/admin/customers/orders.html.erb
+++ b/app/views/admin/customers/orders.html.erb
@@ -1,0 +1,8 @@
+<%= @customer.full_name %>
+<% @orders.each do |order| %>
+  <%= order.name %>
+  <%= order.full_address %>
+  <%= order.payment_method %>
+  <%= order.status %>
+  <%= order.total_price %>
+<% end %>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -33,7 +33,7 @@
           <%= link_to edit_admin_customer_path(@customer), class: "btn btn-success" do %>
             編集する
           <% end %>
-          <%= link_to admin_root_path, class: "btn btn-primary" do %>
+          <%= link_to orders_admin_customer_path, class: "btn btn-primary" do %>
             注文履歴一覧を見る
           <% end %>
         </div>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -33,7 +33,7 @@
           <%= link_to edit_admin_customer_path(@customer), class: "btn btn-success" do %>
             編集する
           <% end %>
-          <%= link_to orders_admin_customer_path, class: "btn btn-primary" do %>
+          <%= link_to orders_admin_customer_path(@customer), class: "btn btn-primary" do %>
             注文履歴一覧を見る
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
     resource :customers do
       collection do
-        get :mypage, to: 'customers#show'
+        get :mypage, to: "customers#show"
         get "mypage/edit", to: "customers#edit"
         patch "mypage/update", to: "customers#update"
         get :confirm
@@ -47,7 +47,11 @@ Rails.application.routes.draw do
 
     resources :genres, only: %i[index create edit update]
 
-    resources :customers, only: %i[index show edit update]
+    resources :customers, only: %i[index show edit update] do
+      member do
+        get :orders
+      end
+    end
 
     resources :orders, only: %i[show update]
 


### PR DESCRIPTION
顧客ごとの注文履歴一覧画面実装について、このルーティングで問題ないかご確認お願いします。

パスは `/admin/customers/:id/orders(.:format)` です。

