### PR TITLE
[fix] enumがバリデーションと干渉する問題の解決

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,25 +1,24 @@
 class Order < ApplicationRecord
+
+  enum payment_method: { credit_card: 0, transfer: 1},
+       status: {
+         awaiting_payment: 0,
+         payment_confirmed: 1,
+         in_production: 2,
+         preparing_for_shipment: 3,
+         shipped: 4
+       }
+
   belongs_to :customer
   has_many :order_details, dependent: :destroy
-
 
   validates :name, presence: true
   validates :zip_code, presence: true
   validates :address, presence: true
-  validates :payment_method, presence: true, inclusion: { in: [0, 1] }
-  validates :status, presence: true, inclusion: { in: [*0..4] }
+  validates :payment_method, presence: true, inclusion: {in: Order.payment_methods.keys}
+  validates :status, presence: true, inclusion: {in: Order.statuses.keys }
   validates :total_price, presence: true
   validates :postage, presence: true
-  
-  enum payment_method: { credit_card: 0, transfer: 1},
-     status: {
-       awaiting_payment: 0,
-       payment_confirmed: 1,
-       in_production: 2,
-       preparing_for_shipment: 3,
-       shipped: 4
-     }
-
 
   def full_address
     "#{self.zip_code} #{self.address}"

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,10 +1,4 @@
 class OrderDetail < ApplicationRecord
-  belongs_to :item
-  belongs_to :order
-
-  validates :price, presence: true
-  validates :amount, presence: true
-  validates :status, presence: true, inclusion: { in: [*0..3] }
 
   enum status: {
     not_producible: 0,
@@ -12,5 +6,12 @@ class OrderDetail < ApplicationRecord
     in_production: 2,
     production_completed: 3
   }
-  
+
+  belongs_to :item
+  belongs_to :order
+
+  validates :price, presence: true
+  validates :amount, presence: true
+  validates :status, presence: true, inclusion: {in: OrderDetail.statuses.keys}
+
 end


### PR DESCRIPTION
バリデーションのincludsionが数値だと認識出来ないらしいので、
キーの文字列にて設定。

enumは本来　上段に書くとのことなのでそこも変更。
下段にかいたままだと認識できずエラーになった。

