### PR TITLE
[add] 顧客側の検索機能実装

### DIFF
--- a/app/assets/stylesheets/public/searches.scss
+++ b/app/assets/stylesheets/public/searches.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/searches controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,4 +1,6 @@
 class Admin::SearchesController < ApplicationController
+  before_action :admin_check
+
   def search
     @word = params[:word]
     search_items
@@ -6,6 +8,10 @@ class Admin::SearchesController < ApplicationController
   end
 
   private
+    def admin_check
+      redirect_to root_path unless admin_signed_in?
+    end
+
     def search_items
       # 商品名検索
       @search_name_items = Item.where("name LIKE?", "%#{@word}%")

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -1,0 +1,19 @@
+class Public::SearchesController < ApplicationController
+  def search
+    @word = params[:word]
+    @category = params[:category]
+    search_items
+  end
+
+  private
+    def search_items
+      case @category
+      when "item"
+      # 商品名検索
+      @search_items = Item.where("name LIKE?", "%#{@word}%")
+      when "genre"
+      # 商品ジャンル検索
+      @search_items = Item.includes(:genre).where(genres: { name: @word }).references(:genre)
+      end
+    end
+end

--- a/app/helpers/admin/searches_helper.rb
+++ b/app/helpers/admin/searches_helper.rb
@@ -4,9 +4,7 @@ module Admin::SearchesHelper
     if admin_signed_in?
       admin_search_path
     else
-      # 未作成のため
-      "#"
-      # customer_search_path
+      customer_search_path
     end
   end
 

--- a/app/helpers/public/searches_helper.rb
+++ b/app/helpers/public/searches_helper.rb
@@ -1,0 +1,9 @@
+module Public::SearchesHelper
+  def category_text(category)
+    categories = {
+      "item" => "商品名：",
+      "genre" => "ジャンル名："
+    }
+    categories[category]
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,6 +29,7 @@
         <!-- 検索フォーム仮設置 -->
         <%= form_with url: search_form_action, method: :get, class: "d-flex justify-content-center align-items-center" do |f| %>
           <%= f.text_field :word, class: "form-control form-control-sm" %>
+          <%= f.hidden_field :category, value: "item" %>
           <%= button_tag type: "submit", class: "ml-2 btn btn-sm" do %>
            <i class="fa-solid fa-magnifying-glass fa-flip-horizontal"></i>
           <% end %>

--- a/app/views/public/homes/_sidebar.html.erb
+++ b/app/views/public/homes/_sidebar.html.erb
@@ -4,7 +4,7 @@
     <% @genres.each do |genre| %>
       <li class="genres-list-item">
         <!-- ジャンル検索実装後、パスを `nil` から適切なものに変更する -->
-        <%= link_to nil, class: "genres-anchor" do %>
+        <%= link_to "#{search_form_action}?category=genre&word=#{genre.name}", class: "genres-anchor" do %>
           <span class="genres-genre-name"><%= genre.name %></span>
           <i class="genres-icon-chevron fa-solid fa-chevron-right"></i>
         <% end %>

--- a/app/views/public/searches/search.html.erb
+++ b/app/views/public/searches/search.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <h4>検索結果画面</h4>
+  </div>
+  <div class="row">
+    <h5>
+      <%= category_text(@category) %>
+      <strong><%= @word %></strong>
+      の検索結果
+    </h5>
+  </div>
+  <div class="row">
+    <%= render "admin/items/table", items: @search_items %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
     end
 
     resources :addresses, except: %i[new show]
+
+    get 'searches/search', as: "customer_search"
   end
 
   namespace :admin do

--- a/test/controllers/public/searches_controller_test.rb
+++ b/test/controllers/public/searches_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Public::SearchesControllerTest < ActionDispatch::IntegrationTest
+  test "should get search" do
+    get public_searches_search_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
顧客側の検索機能実装

レイアウトはとりあえず管理者側と同じにしてあります。
顧客側の商品一覧画面が完成次第そちらのレイアウトに移行予定です。

便宜上ルーティングはcustomer_search_pathにしましたが、ログインなしでも使用可能とっています。
管理者用検索画面には入れないようにはしました。