### PR TITLE
[fix] enum導入に伴い条件分岐が機能していなかったため修正

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -19,7 +19,7 @@ class Admin::OrdersController < ApplicationController
         flash[:notice] = "注文ステータスを更新しました。"
       else
         # メッセージは未実装
-        flash[:notice] = "すべての商品を制作完了にしてください。"
+        flash[:alert] = "すべての商品を制作完了にしてください。"
       end
     else
       order.update(status: new_status)

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -18,7 +18,6 @@ class Admin::OrdersController < ApplicationController
         order.update(status: new_status)
         flash[:notice] = "注文ステータスを更新しました。"
       else
-        # メッセージは未実装
         flash[:alert] = "すべての商品を制作完了にしてください。"
       end
     else

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -16,6 +16,7 @@ class Admin::OrdersController < ApplicationController
     if new_status == 4
       if order.complete_all_details?
         order.update(status: new_status)
+        flash[:notice] = "注文ステータスを更新しました。"
       else
         # メッセージは未実装
         flash[:notice] = "すべての商品を制作完了にしてください。"

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -25,6 +25,6 @@ class Order < ApplicationRecord
   end
 
   def complete_all_details?
-    order_details.all? { |detail| detail.status == 3 }
+    order_details.all? { |detail| detail.status_before_type_cast == 3 }
   end
 end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,8 +1,5 @@
 <div class="container">
   <div class="row">
-    <h5><%= flash[:notice] %></h5>
-  </div>
-  <div class="row">
     <h5 class="offset-1 my-3">注文履歴詳細</h5>
   </div>
   <div class="row">


### PR DESCRIPTION
order_detailのステータスが全て制作済みにならないと
orderのステータスを発送済みに出来ないよう条件づけをしていたところが
enum導入でバグになっていたので修正。

