### PR TITLE
[fix] カートが空の際に新規注文関係のページに飛べないようにした

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,4 +1,5 @@
 class Public::OrdersController < ApplicationController
+  before_action :check_cart_empty, only: %i[new confirm create complete]
 
   def new
     @order = Order.new
@@ -97,7 +98,7 @@ class Public::OrdersController < ApplicationController
     # 新規住所を登録して配送先として使用
     def set_address_from_params
       if address_params.values.any?(&:blank?)
-        redirect_to new_order_path, flash: { error: "配送先が入力されていません" }
+        redirect_to new_order_path, alert: "配送先が入力されていません"
       else
         assign_address(*address_params.values)
         current_customer.addresses.create(address_params)
@@ -109,6 +110,12 @@ class Public::OrdersController < ApplicationController
       @order.zip_code = zip_code
       @order.address = address
       @order.name = name
+    end
+
+    def check_cart_empty
+      if current_customer.cart_items.empty?
+        redirect_to items_path, alert: "カートに商品がありません"
+      end
     end
 
 end


### PR DESCRIPTION
コントローラで条件付けしてカートに商品がない場合は
アラートを出した上で商品一覧画面に移動するように仕様変更した。
