### PR TITLE
[fix] customerのカラムの日本語を登録

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
       customer:
         email: メールアドレス
         password: パスワード
+        password_confirmation: 確認用パスワード
         first_name: 名前(名)
         last_name: 名前(姓)
         first_name_kana: フリガナ(メイ)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,19 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      customer: 顧客
+    attributes:
+      customer:
+        email: メールアドレス
+        password: パスワード
+        first_name: 名前(名)
+        last_name: 名前(姓)
+        first_name_kana: フリガナ(メイ)
+        last_name_kana: フリガナ(セイ)
+        zip_code: 郵便番号
+        address: 住所
+        telephone_number: 電話番号
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
customerの各カラムの日本語を設定。

とりあえず、新規登録画面にて発生する
エラーメッセージが日本語になっていることは確認しました。

文字数などのバリデーションについては未設定だったので確認していませんが、多分大丈夫です。