### PR TITLE
Fix/cart items controller

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,64 +1,80 @@
 class Public::CartItemsController < ApplicationController
+  before_action :set_cart_items, only: %i[index update destroy destroy_all]
+
   def index
-    @cart_items = current_customer.cart_items
     @total_price = CartItem.total_price(@cart_items)
   end
 
   def create
-    cart_item = CartItem.new(cart_item_params)
-    cart_item.customer_id = current_customer.id
-    cart_item.item_id = cart_item_params[:item_id]
-    # カート内に存在するなら
-    if CartItem.find_by(item_id: params[:cart_item][:item_id]).present?
-      cart_item = CartItem.find_by(item_id: params[:cart_item][:item_id])
-      # 数量を加算
-      cart_item.amount += params[:cart_item][:amount].to_i
-      cart_item.update(amount: cart_item.amount)
-      redirect_to cart_items_path
+    item_id = cart_item_params[:item_id]
+    new_amount = cart_item_params[:amount].to_i
+
+    @cart_item = CartItem.find_or_initialize_by(
+      customer_id: current_customer.id,
+      item_id: item_id
+    )
+
+    item_name = @cart_item.item.name
+
+    # カート内に既に存在するなら
+    if @cart_item.new_record?
+      @cart_item.amount = new_amount
     else
-      cart_item.save
-      redirect_to cart_items_path
+      @cart_item.amount += new_amount
+    end
+
+    if @cart_item.save
+      redirect_to cart_items_path, notice: "#{item_name}をカートに追加しました。"
+    else
+      @item = Item.find(item_id)
+      @genres = Genre.all
+      render "public/items/show"
     end
   end
 
   def update
-    @cart_items = current_customer.cart_items
-    @cart_item = current_customer.cart_items.find_by(
-      item_id: params[:cart_item][:item_id]
+    @cart_item = @cart_items.find_by(
+      item_id: cart_item_params[:item_id]
     )
 
-    selected_amount = params[:cart_item][:amount]
+    selected_amount = cart_item_params[:amount]
+    item_name = @cart_item.item.name
+
     @cart_item.update(amount: selected_amount)
 
-    # redirect_to cart_items_path
+    flash.now[:notice] = "#{item_name}の数量を#{selected_amount}個に変更しました。"
     render :cart_table
   end
 
   def destroy
-    @cart_items = current_customer.cart_items
-    @cart_item = current_customer.cart_items.find_by(item_id: params[:id])
+    @cart_item = @cart_items.find_by(item_id: params[:id])
+
     if @cart_item
       @item_name = @cart_item.item.name
       @cart_item.destroy
-      flash.now[:notice] = "#{@item_name}を削除しました。"
+
+      flash.now[:notice] = "#{@item_name}をカートから削除しました。"
       render :cart_table
     else
-      # カート内アイテムが見つからなかったときの処理
+
       flash.now[:alert] = "選択した商品が見つかりませんでした。"
       render :cart_table
     end
   end
 
   def destroy_all
-    @cart_items = current_customer.cart_items
-    current_customer.cart_items.destroy_all
-    # redirect_to cart_items_path, notice: "カートを空にしました。"
+    @cart_items.destroy_all
+
+    flash.now[:notice] = "カートを空にしました。"
     render :cart_table
   end
 
   private
-
   def cart_item_params
     params.require(:cart_item).permit(:item_id, :amount)
+  end
+
+  def set_cart_items
+    @cart_items = current_customer.cart_items
   end
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,5 +1,5 @@
 class Public::OrdersController < ApplicationController
-  before_action :check_cart_empty, only: %i[new confirm create complete]
+  before_action :check_cart_empty, only: %i[new confirm create]
 
   def new
     @order = Order.new

--- a/app/views/public/cart_items/_empty-cart-button.html.erb
+++ b/app/views/public/cart_items/_empty-cart-button.html.erb
@@ -1,0 +1,9 @@
+<%= link_to(
+  destroy_all_cart_items_path,
+  method: :delete,
+  remote: true,
+  "data-confirm": "カートを空にしますか？",
+  class: "btn btn-danger btn-sm #{"disabled" if disabled }"
+) do %>
+  カートを空にする
+<% end %>

--- a/app/views/public/cart_items/_order-button.html.erb
+++ b/app/views/public/cart_items/_order-button.html.erb
@@ -1,0 +1,3 @@
+<%= link_to new_order_path, class: "btn btn-success #{"disabled" if disabled }" do %>
+  情報入力に進む
+<% end %>

--- a/app/views/public/cart_items/_table-row.html.erb
+++ b/app/views/public/cart_items/_table-row.html.erb
@@ -1,0 +1,37 @@
+<%
+  item = cart_item.item
+  taxed_price = item.taxed_price
+  amount = cart_item.amount
+%>
+<tr>
+  <td>
+    <%= image_tag item.image, size: "48x48" %>
+    <%= item.name %>
+  </td>
+  <td><%= to_jpy_format(taxed_price, false) %></td>
+  <td>
+    <%= form_with model: cart_item, method: :patch, local: false do |f| %>
+      <%= f.hidden_field :item_id, value: item.id %>
+      <div class="form-group d-flex align-items-center">
+        <div>
+          <%= f.select :amount, amount_range(amount), { selected: amount }, class: "form-control" %>
+        </div>
+        <%= f.button type: "submit", remote: true, class: "btn btn-success mx-2" do %>
+          変更
+        <% end %>
+      </div>
+    <% end %>
+  </td>
+  <td><%= to_jpy_format(cart_item.subtotal, false) %></td>
+  <td>
+    <%= link_to(
+      cart_item_path(item.id),
+      method: :delete,
+      remote: true,
+      "data-confirm": "#{item.name}を削除しますか？",
+      class: "btn btn-danger btn-sm"
+    ) do %>
+      削除する
+    <% end %>
+  </td>
+</tr>

--- a/app/views/public/cart_items/cart_table.js.erb
+++ b/app/views/public/cart_items/cart_table.js.erb
@@ -1,2 +1,7 @@
-$('#cart_items_table').html('<%= j(render "table", cart_item: @cart_item, cart_items: @cart_items) %>');
-$('#flash').html('<%= j(render "layouts/notification") %>');
+$("#cart-items-table").html("<%= j(render partial: "table-row", collection: @cart_items, as: :cart_item) %>");
+$("#flash").html("<%= j(render "layouts/notification") %>");
+
+<% if @cart_items.empty? %>
+  $("#order-button").html("<%= j(render "order-button", disabled: true) %>");
+  $("#empty-cart-button").html("<%= j(render "empty-cart-button", disabled: true) %>");
+<% end %>

--- a/app/views/public/cart_items/cart_table.js.erb
+++ b/app/views/public/cart_items/cart_table.js.erb
@@ -1,2 +1,2 @@
 $('#cart_items_table').html('<%= j(render "table", cart_item: @cart_item, cart_items: @cart_items) %>');
-$('#flash').html('<%= j(render "layouts/notification", cart_item: @cart_item) %>');
+$('#flash').html('<%= j(render "layouts/notification") %>');

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,13 +1,10 @@
 <section class="container">
   <div class="d-flex justify-content-between">
     <div class="h3">ショッピングカート</div>
-    <div>
-      <%= link_to destroy_all_cart_items_path, method: :delete, remote: true, "data-confirm": "カートを空にしますか？", class: "btn btn-danger btn-sm" do %>
-        カートを空にする
-      <% end %>
+    <div id="empty-cart-button">
+      <%= render "empty-cart-button", disabled: @cart_items.empty? %>
     </div>
   </div>
-  <%= @test %>
   <% if @cart_items.size == 0 %>
     <p>
       カートは空です。
@@ -23,8 +20,8 @@
           <th></th>
         </tr>
       </thead>
-      <tbody id="cart_items_table">
-        <%= render "table", cart_item: @cart_item, cart_items: @cart_items %>
+      <tbody id="cart-items-table">
+        <%= render partial: "table-row", collection: @cart_items, as: :cart_item %>
       </tbody>
     </table>
   <% end %>
@@ -43,9 +40,7 @@
       </div>
     </div>
   </div>
-  <div class="my-2 text-center">
-    <%= link_to new_order_path, class: "btn btn-success" do %>
-      情報入力に進む
-    <% end %>
+  <div id="order-button" class="my-2 text-center">
+    <%= render "order-button", disabled: @cart_items.empty? %>
   </div>
 </section>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-3 text-center">
       <%= image_tag @item.image %>
     </div>
-    <div class="offset-md-1 col-md-8">
+    <div class="offset-md-1 col-md-7">
       <h2 class="marked-heading"><%= @item.name %></h2>
       <p class="mt-2 mb-5">
         <%= @item.introduction %>
@@ -20,15 +20,12 @@
           </div>
         <% elsif customer_signed_in? %>
           <!-- ログイン時 -->
+          <%= render "layouts/errors", model: @cart_item %>
           <%= form_with model: @cart_item, local: true do |f| %>
             <%= f.hidden_field :item_id, value: @item.id %>
-            <div class="d-flex">
-              <div class="w-50 text-center">
-                <%= f.select :amount, amount_range, { include_blank: "個数選択" }, class: "form-control" %>
-              </div>
-              <div class="w-50 text-center">
-                <%= f.submit "カートに追加", class: "btn btn-success" %>
-              </div>
+            <div class="form-row">
+              <%= f.select :amount, amount_range, { include_blank: "個数選択" }, class: "form-control offset-1 col-5 col-xl-3" %>
+              <%= f.submit "カートに追加", class: "btn btn-success offset-1 col-4 col-xl-3" %>
             </div>
           <% end %>
         <% else %>


### PR DESCRIPTION
https://github.com/Reflux-esophagitis/nagano_cake/issues/73 と https://github.com/Reflux-esophagitis/nagano_cake/issues/83 の修正。
https://github.com/Reflux-esophagitis/nagano_cake/pull/78 のデグレも発見したのでついでに修正。

- 商品の数量が不正な状態でカートに追加しようとしたときにエラーメッセージを表示するように修正しました。
- CartItemsController内のコード全体をリファクタリングしました。
- カートに追加時、数量変更時、カートを空にしたときにフラッシュメッセージを表示するようにしました。
- カートが空のときに「カートを空にする」ボタンと「 情報入力に進む」ボタンを無効化するようにしました。
- 上記のボタン無効化について非同期処理にも対応しました。
- カート画面でのtableパーシャルはrender collectionを使うように修正しました。
- 注文確定時に、完了画面に遷移せずカートに商品がない旨のアラートが表示される不具合を修正しました。