### PR TITLE
[fix] is_activeのバリデーションを修正

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -16,6 +16,7 @@ class Customer < ApplicationRecord
   validates :address, presence: true
   validates :telephone_number, presence: true
   validates :email, presence: true
+  validates :is_active, inclusion: [true, false]
 
   def full_name
     self.last_name + self.first_name

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :introduction, presence: true
   validates :non_taxed_price, presence: true
-  validates :is_active, presence: true
+  validates :is_active, inclusion: [true, false]
 
   scope :active, -> { where(is_active: true) }
   # ジャンルデータを事前読み込み


### PR DESCRIPTION
CustomerとItemの `is_active` カラムのバリデーションを修正しました。
boolean型のカラムに `presence: true` のバリデーションを設定すると `false` は空扱いされるため保存ができなくなります。
[参考：Railsガイド](https://railsguides.jp/active_record_validations.html#:~:text=false.blank%3F%E3%81%AF%E5%B8%B8%E3%81%ABtrue%E3%81%AA%E3%81%AE%E3%81%A7%E3%80%81%E7%9C%9F%E5%81%BD%E5%80%A4%E3%81%AB%E5%AF%BE%E3%81%97%E3%81%A6%E3%81%93%E3%81%AE%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%82%92%E4%BD%BF%E3%81%86%E3%81%A8%E6%AD%A3%E3%81%97%E3%81%84%E7%B5%90%E6%9E%9C%E3%81%8C%E5%BE%97%E3%82%89%E3%82%8C%E3%81%BE%E3%81%9B%E3%82%93%E3%80%82%E7%9C%9F%E5%81%BD%E5%80%A4%E3%81%AE%E5%AD%98%E5%9C%A8%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%97%E3%81%9F%E3%81%84%E5%A0%B4%E5%90%88%E3%81%AF%E3%80%81%E4%BB%A5%E4%B8%8B%E3%81%AE%E3%81%84%E3%81%9A%E3%82%8C%E3%81%8B%E3%82%92%E4%BD%BF%E3%81%86%E5%BF%85%E8%A6%81%E3%81%8C%E3%81%82%E3%82%8A%E3%81%BE%E3%81%99%E3%80%82)
