### PR TITLE
[fix] 画面幅が狭いときに検索フォームが崩れるのを修正

### DIFF
--- a/app/javascript/stylesheets/global/_header.scss
+++ b/app/javascript/stylesheets/global/_header.scss
@@ -17,6 +17,10 @@
   @include media-breakpoint-down(lg) {
     height: 20px;
   }
+
+  @include media-breakpoint-down(md) {
+    height: 16px;
+  }
 }
 
 @include media-breakpoint-down(md) {


### PR DESCRIPTION
管理者側ログイン時、画面幅を狭めると検索フォームが崩れてしまうため、ロゴのサイズ調整を行い修正しました。